### PR TITLE
pid assigned for new traceparent

### DIFF
--- a/txmiddleware.go
+++ b/txmiddleware.go
@@ -26,6 +26,7 @@ func TxContextMiddleware(factory TxFactory) gin.HandlerFunc {
 				)
 				return
 			}
+			pid = tid
 		}
 
 		// Generate a new resource id


### PR DESCRIPTION
The parent id will be the overall trace id when a new trace is being created (at least that's how it works with operation ids in application insights)